### PR TITLE
Fix code scanning alert no. 2: Insecure configuration of Helmet security middleware

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,8 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
   app.use(
     helmet({
-      contentSecurityPolicy: false,
+      contentSecurityPolicy: true,
+      frameguard: { action: 'sameorigin' },
       originAgentCluster: true,
     }),
   );


### PR DESCRIPTION
Fixes [https://github.com/Noureldin2303/BookNest/security/code-scanning/2](https://github.com/Noureldin2303/BookNest/security/code-scanning/2)

To fix the problem, we need to enable the Content Security Policy (CSP) in the Helmet configuration. This can be done by either using the default CSP settings provided by Helmet or by specifying a custom CSP configuration that suits the application's needs. Additionally, we should ensure that the `frameguard` option is enabled to protect against clickjacking attacks.

The best way to fix the problem without changing existing functionality is to update the Helmet configuration in the `src/main.ts` file. We will enable the default CSP settings and explicitly set the `frameguard` option to its default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
